### PR TITLE
Enable gpl for all linux builds, remove appimage from pipeline

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -207,10 +207,6 @@ jobs:
           sudo add-apt-repository universe
           sudo apt-get update
           sudo apt-get install libfuse2 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit libgtk-3-dev
-          git clone https://github.com/FFmpeg/nv-codec-headers.git
-          cd nv-codec-headers/
-          sudo make install
-          cd ..
           cp alvr/xtask/deb/cuda.pc /usr/share/pkgconfig
           cargo xtask prepare-deps --platform linux
 
@@ -219,7 +215,7 @@ jobs:
           RUST_BACKTRACE: 1
         run: |
           cargo xtask bump --nightly
-          cargo xtask package-streamer
+          cargo xtask package-streamer --gpl
       - name: Upload linux streamer
         uses: actions/upload-release-asset@v1
         env:
@@ -229,30 +225,6 @@ jobs:
           asset_path: ./build/alvr_streamer_linux.tar.gz
           asset_name: alvr_streamer_linux.tar.gz
           asset_content_type: application/gzip
-
-      - name: Build and package ALVR (AppImage)
-        env:
-          RUST_BACKTRACE: 1
-        run: |
-          cargo xtask package-streamer --appimage --zsync
-      - name: Upload linux streamer (AppImage)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/ALVR-x86_64.AppImage
-          asset_name: ALVR-x86_64.AppImage
-          asset_content_type: application/x-executable
-      - name: Upload linux streamer (AppImage.zsync)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.prepare_release.outputs.upload_url }}
-          asset_path: ./build/ALVR-x86_64.AppImage.zsync
-          asset_name: ALVR-x86_64.AppImage.zsync
-          asset_content_type: application/octet-stream
 
   build_linux_streamer_debug:
     runs-on: ubuntu-latest
@@ -274,10 +246,6 @@ jobs:
           sudo add-apt-repository universe
           sudo apt-get update
           sudo apt-get install libfuse2 build-essential pkg-config nasm libva-dev libdrm-dev libvulkan-dev libx264-dev libx265-dev cmake libasound2-dev libjack-jackd2-dev libxrandr-dev libunwind-dev libffmpeg-nvenc-dev nvidia-cuda-toolkit libgtk-3-dev
-          git clone https://github.com/FFmpeg/nv-codec-headers.git
-          cd nv-codec-headers/
-          sudo make install
-          cd ..
           cp alvr/xtask/deb/cuda.pc /usr/share/pkgconfig
           cargo xtask prepare-deps --platform linux
 
@@ -286,7 +254,7 @@ jobs:
           RUST_BACKTRACE: 1
         run: |
           cargo xtask bump --nightly
-          cargo xtask build-streamer
+          cargo xtask build-streamer --gpl
           tar -czvf ./build/alvr_streamer_linux.tar.gz -C ./build alvr_streamer_linux
       - name: Upload linux streamer
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Remove appimage from builds (as tar.gz is already portable enough)
Remove unnecessary nvenc headers installation as they are downloaded during build now

Similar PR needs to be made on ALVR stable branch