### PR TITLE
fix: nightly release build failures

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -169,6 +169,12 @@ jobs:
           RUST_BACKTRACE: 1
         run: |
           cargo xtask bump --nightly
+          # Create libvpl license directory if it doesn't exist
+          if (!(Test-Path "deps/windows/libvpl/alvr_build/share/vpl/licensing")) {
+            New-Item -ItemType Directory -Path "deps/windows/libvpl/alvr_build/share/vpl/licensing" -Force
+            # Download LICENSE from GitHub
+            Invoke-WebRequest -Uri "https://raw.githubusercontent.com/intel/libvpl/main/LICENSE" -OutFile "deps/windows/libvpl/alvr_build/share/vpl/licensing/license.txt"
+          }
           cargo xtask package-launcher --ci
 
       - name: Upload portable launcher (zip)


### PR DESCRIPTION
Fix nightly release workflow failure & add libvpl LICENSE download

### Description
This PR addresses the persistent failures in the nightly release workflow starting from the run linked below:  
https://github.com/alvr-org/ALVR-nightly/actions/runs/20474199147
(Release nightly #1995: Scheduled, Dec 24, 2025, 7:47 AM GMT+8)

### Key Changes
- Download the LICENSE file for libvpl as part of the nightly release pipeline, resolving missing file-related workflow errors.(in this pull request)
```bash
thread 'main' (5688) panicked at alvr\xtask\src\packaging.rs:59:10:
called `Result::unwrap()` on an `Err` value: failed to copy `D:\a\ALVR-nightly\ALVR-nightly\deps\windows/libvpl/alvr_build/share/vpl/licensing/license.txt` to `D:\a\ALVR-nightly\ALVR-nightly\build\alvr_launcher_windows\licenses\libvpl.txt`: The system cannot find the path specified. (os error 3)
```
- fix `cargo about` tool invocation errors.(https://github.com/alvr-org/ALVR/pull/3216)
```bash
2026-02-26 0:20:30.5227682 +00:00:00 [ERROR] cargo-about should not redirect its output in powershell, please use the -o, --output-file option to redirect to a file to avoid powershell encoding issues
```

### Testing & Validation
After implementing these changes:
- The GitHub Actions workflow for nightly releases now executes successfully without failures.
- I have successfully installed and tested the modified build on a Pico Neo 3 device.
- Following the libvpl upgrade included in these changes, the macroblocking issue on my B580 graphics card has been resolved, and the application no longer crashes when using high presets.

### Additional Notes
I’ve verified end-to-end functionality to ensure no regressions in core ALVR features.

Thank you for reviewing this PR! Please let me know if any additional adjustments or tests are needed to get this merged.

Best regards,  
Zhaosn